### PR TITLE
wire public site to Daleel-Backend /api/n

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(curl -s -o /dev/null -w \"HTTP:%{http_code} time:%{time_total}s\\\\n\" \"http://localhost:3000/api/n/latest?pageSize=1\")",
+      "Bash(curl -s \"http://localhost:3000/health\")",
+      "Bash(curl -s -o /dev/null -w \"HTTP:%{http_code} time:%{time_total}s\\\\n\" \"http://localhost:3001/en/news\" --max-time 30)",
+      "Bash(pm2 save *)",
+      "Bash(pm2 restart *)",
+      "Bash(curl -s -o /dev/null -w \"HTTP:%{http_code} news-list\\\\n\" \"http://localhost:3001/en/news?category=inzar\" --max-time 20)",
+      "Bash(curl -s \"http://localhost:3000/api/n/latest?pageSize=1\")",
+      "Bash(node -e 'const r=require\\(\"fs\"\\).readFileSync\\(0,\"utf8\"\\); const d=JSON.parse\\(r\\); console.log\\(\"detail-test-id:\",d.data[0].id\\)')",
+      "Bash(curl -s -o /dev/null -w \"HTTP:%{http_code} homepage\\\\n\" \"http://localhost:3001/en\" --max-time 20)",
+      "Bash(pm2 status *)",
+      "Bash(pm2 logs *)",
+      "Bash(tasklist //FI \"PID eq 17156\")",
+      "Bash(wmic process *)",
+      "Bash(taskkill //PID 17156 //F)",
+      "Bash(curl -s -o /dev/null -w \"news:%{http_code} \" \"http://localhost:3001/en/news\" --max-time 20)",
+      "Bash(curl -s -o /dev/null -w \"news/10999:%{http_code} \" \"http://localhost:3001/en/news/10999\" --max-time 20)",
+      "Bash(curl -s -o /dev/null -w \"home:%{http_code}\\\\n\" \"http://localhost:3001/en\" --max-time 20)",
+      "Bash(git remote *)",
+      "Bash(gh pr create --repo Kronbii/daleel --base main --head laythayache:main --title 'wire public site to Daleel-Backend /api/n' --body ' *)"
+    ]
+  }
+}

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,5 +1,4 @@
 # Files and directories to ignore during Vercel deployment
-
 # Development files
 *.log
 .env.local
@@ -36,4 +35,3 @@ scripts/
 
 # Data files (not needed in deployment)
 data/
-

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -15,8 +15,7 @@
       "@/api/*": ["./src/api/*"],
       "@/lib/*": ["./src/lib/*"],
       "@/shared/*": ["../shared/*"]
-    },
-    "baseUrl": "."
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/docs/backend-platform-prompt.md
+++ b/docs/backend-platform-prompt.md
@@ -1,0 +1,302 @@
+# Backend Platform — Build Prompt
+
+You are building a **private backend platform** for the Daleel project. This is a completely separate system from the public Vercel website. It is the operational brain of the entire project.
+
+---
+
+## What this system does
+
+This platform has three jobs:
+
+1. **Collect** — Ingest data from Telegram channels
+2. **Manage** — Store, process, curate, and visualize that data through an internal admin dashboard
+3. **Publish** — Expose only approved, normalized data (`N`) through a public API that the Vercel website consumes
+
+The full pipeline is:
+
+```
+Telegram → Ingestion Service → Database → Admin Dashboard → Public API → (Vercel website reads from here)
+```
+
+The Vercel website is a separate repo. It is NOT part of this project. This platform only needs to serve the public API that the Vercel site will call.
+
+---
+
+## The concept of `N`
+
+`N` is the normalized, website-ready version of raw Telegram content. Telegram data is messy (raw text, media, metadata, duplicates, inconsistent formatting). `N` is the cleaned, structured object that the public website renders.
+
+### `N` schema
+
+```typescript
+interface N {
+  id: string                  // UUID
+  title: string               // Cleaned title (extracted or written manually)
+  summary: string             // Short preview text
+  body: string                // Full content (supports markdown)
+  imageUrl?: string           // Primary image URL (if any)
+  sourceUrl?: string          // Link to original Telegram post
+  sourceName: string          // Channel or source name
+  category: string            // e.g., "news", "announcement", "analysis", "leak", "statement"
+  tags: string[]              // Freeform tags for filtering
+  status: 'draft' | 'review' | 'published' | 'hidden'  // Publish state
+  language: 'ar' | 'en' | 'fr'  // Primary language of the content
+  telegramMessageId?: number  // Original Telegram message ID (for dedup)
+  telegramChannelId?: string  // Original Telegram channel/chat ID
+  rawTelegramData?: object    // Full raw payload from Telegram (stored but not exposed publicly)
+  createdAt: Date             // When the item was first ingested
+  updatedAt: Date             // Last modification
+  publishedAt?: Date          // When it was marked published
+  fetchedAt: Date             // When it was fetched from Telegram
+}
+```
+
+The public API should NEVER expose `rawTelegramData`. That field is internal only.
+
+---
+
+## Architecture components
+
+### 1. Telegram Ingestion Service
+
+A background worker that periodically fetches new posts from configured Telegram channels.
+
+**Responsibilities:**
+- Connect to Telegram (use GramJS/Telethon or Telegram Bot API — your choice)
+- Fetch new messages from configured channels
+- Detect and skip duplicates (by `telegramMessageId` + `telegramChannelId`)
+- Store raw Telegram data in the database
+- Create initial `N` objects with status `draft` (auto-extract title, body, media URLs)
+- Log every sync attempt (success/failure, items fetched, errors)
+
+**Configuration needed:**
+- List of Telegram channels to watch
+- Polling interval (e.g., every 5 minutes)
+- Telegram API credentials (API ID, API hash, or bot token)
+
+### 2. Database
+
+PostgreSQL with the following tables (at minimum):
+
+#### `telegram_raw`
+Stores the exact raw data from Telegram as-is.
+- `id` (UUID, PK)
+- `telegram_message_id` (integer)
+- `telegram_channel_id` (string)
+- `raw_payload` (JSONB — the full Telegram message object)
+- `media_urls` (JSONB — array of extracted media URLs)
+- `fetched_at` (timestamp)
+- `created_at` (timestamp)
+- UNIQUE constraint on (`telegram_message_id`, `telegram_channel_id`)
+
+#### `items` (this is the `N` table)
+- `id` (UUID, PK)
+- `telegram_raw_id` (FK → telegram_raw, nullable — manual entries won't have this)
+- `title` (text)
+- `summary` (text)
+- `body` (text)
+- `image_url` (text, nullable)
+- `source_url` (text, nullable)
+- `source_name` (text)
+- `category` (text)
+- `tags` (JSONB — string array)
+- `status` (enum: draft, review, published, hidden)
+- `language` (enum: ar, en, fr)
+- `created_at` (timestamp)
+- `updated_at` (timestamp)
+- `published_at` (timestamp, nullable)
+- `fetched_at` (timestamp)
+
+#### `sync_jobs`
+- `id` (UUID, PK)
+- `channel_id` (text)
+- `started_at` (timestamp)
+- `ended_at` (timestamp, nullable)
+- `status` (enum: running, success, failed)
+- `items_fetched` (integer, default 0)
+- `items_created` (integer, default 0)
+- `duplicates_skipped` (integer, default 0)
+- `error_message` (text, nullable)
+
+#### `channels`
+- `id` (UUID, PK)
+- `telegram_id` (text, unique)
+- `name` (text)
+- `is_active` (boolean, default true)
+- `last_synced_at` (timestamp, nullable)
+- `created_at` (timestamp)
+
+#### `users` (for admin dashboard auth)
+- `id` (UUID, PK)
+- `email` (text, unique)
+- `password_hash` (text)
+- `role` (enum: admin, editor)
+- `created_at` (timestamp)
+
+### 3. Internal Admin Dashboard
+
+A web application for the project owner to manage everything. This is NOT public-facing.
+
+**Tech:** Use any modern framework (Next.js, Nuxt, SvelteKit, etc.) with a clean UI.
+
+#### Pages needed:
+
+**a) Overview / Home**
+- System health at a glance
+- Is the ingestion worker running?
+- Last successful sync time
+- Items fetched today
+- Items published vs draft vs hidden
+- Recent errors (if any)
+- Pending items awaiting review
+
+**b) Items Manager (the `N` manager)**
+This is the most important page. It's a mini CMS.
+- Table/list view of all `N` items with search, filter by status/category/channel/date
+- Click to edit: title, summary, body, category, tags, image URL
+- Bulk actions: publish, hide, delete
+- Status workflow: draft → review → published (or → hidden)
+- Preview: show how the item would appear on the public site
+- Create new item manually (not from Telegram)
+
+**c) Raw Telegram Data**
+- Table of all raw Telegram messages
+- Show: channel, message ID, raw text preview, media count, fetch time
+- Link to the `N` item created from it (if any)
+- Useful for debugging and auditing
+
+**d) Channels**
+- List of configured Telegram channels
+- Add/remove/enable/disable channels
+- Show last sync time per channel
+- Trigger manual sync for a specific channel
+
+**e) Sync Logs**
+- Table of all sync jobs
+- Show: channel, start time, end time, status, items fetched/created, duplicates skipped, errors
+- Filter by status, channel, date range
+
+**f) Analytics**
+- Posts per day (chart)
+- Posts by channel (chart)
+- Published vs draft vs hidden (chart)
+- Categories breakdown (chart)
+- Tags cloud or frequency
+
+### 4. Public API
+
+REST API endpoints that the Vercel website will call. These return ONLY published `N` items.
+
+**Endpoints:**
+
+```
+GET /api/n/latest?limit=20&offset=0
+  → Returns latest published items, paginated
+
+GET /api/n/list?page=1&pageSize=20&category=news&tag=election&language=ar&q=searchterm
+  → Returns filtered, paginated list of published items
+
+GET /api/n/:id
+  → Returns a single published item by ID
+
+GET /api/n/categories
+  → Returns list of categories with item counts
+
+GET /api/n/tags
+  → Returns list of tags with item counts
+```
+
+**Response format** (match the Vercel app's existing pattern):
+
+```json
+{
+  "success": true,
+  "data": [ ... ],
+  "total": 150,
+  "page": 1,
+  "pageSize": 20,
+  "totalPages": 8
+}
+```
+
+For single items:
+```json
+{
+  "success": true,
+  "data": { ... }
+}
+```
+
+**IMPORTANT:** The public API must:
+- Never return items with status other than `published`
+- Never return `rawTelegramData`
+- Support CORS for the Vercel domain
+- Be rate-limited (100 requests/minute per IP)
+
+---
+
+## Security requirements
+
+- Admin dashboard must be behind authentication (session-based or JWT)
+- Public API is read-only, no auth needed, but rate-limited
+- Telegram API credentials stored in environment variables, never in code
+- Raw Telegram data never exposed through the public API
+- CSRF protection on admin actions
+
+---
+
+## Environment variables needed
+
+```env
+# Database
+DATABASE_URL=postgresql://user:pass@host:5432/daleel_backend
+
+# Telegram
+TELEGRAM_API_ID=your_api_id
+TELEGRAM_API_HASH=your_api_hash
+TELEGRAM_BOT_TOKEN=your_bot_token  # if using bot API
+TELEGRAM_SESSION=session_string     # if using user client
+
+# Admin Auth
+ADMIN_JWT_SECRET=random_secret
+# or session-based auth secret
+
+# Public API
+CORS_ORIGIN=https://your-vercel-domain.vercel.app
+RATE_LIMIT_MAX=100
+RATE_LIMIT_WINDOW_MS=60000
+
+# Ingestion
+SYNC_INTERVAL_MS=300000  # 5 minutes
+```
+
+---
+
+## What to build first (priority order)
+
+1. **Database schema + migrations** — Set up PostgreSQL with all tables
+2. **Telegram ingestion service** — Get data flowing from Telegram into the DB
+3. **Public API** — Serve published `N` items (so the Vercel site can start consuming)
+4. **Admin dashboard** — Build the management UI
+5. **Analytics** — Add charts and visualization
+
+---
+
+## What this system is NOT
+
+- This is NOT the public website. The public website is a separate Next.js app on Vercel.
+- This system does NOT serve HTML to end users. It serves JSON through the public API.
+- The admin dashboard is for the project owner only, not for public visitors.
+- This system does NOT need to know about candidates, districts, electoral lists, or any of the existing Daleel election data models. Those belong to the Vercel app. This system only deals with Telegram content → `N`.
+
+---
+
+## Hosting
+
+This platform needs to run on a server that supports:
+- Long-running background processes (the ingestion worker)
+- PostgreSQL database
+- Web server for the admin dashboard and API
+
+Good options: VPS (DigitalOcean, Hetzner, Linode), Railway, Fly.io, or a home server.
+It should NOT be deployed on Vercel (Vercel doesn't support long-running workers).

--- a/frontend/src/app/[locale]/news/[id]/page.tsx
+++ b/frontend/src/app/[locale]/news/[id]/page.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { getItemById } from "@/lib/n-client";
+
+const CATEGORY_LABEL_KEY: Record<string, "alert" | "announcement" | "general"> = {
+  inzar: "alert",
+  politics: "announcement",
+  news: "general",
+};
+
+const CATEGORY_STYLE: Record<string, string> = {
+  inzar: "bg-amber-50 text-amber-800 border-amber-200",
+  politics: "bg-blue-50 text-blue-800 border-blue-200",
+  news: "bg-gray-50 text-gray-700 border-gray-200",
+};
+
+const ORIENTATION_STYLE: Record<string, string> = {
+  "pro-March 14": "bg-sky-50 text-sky-700 border-sky-200",
+  "pro-Hezbollah": "bg-yellow-50 text-yellow-800 border-yellow-200",
+  "pro-Amal": "bg-emerald-50 text-emerald-700 border-emerald-200",
+  "pro-FPM": "bg-orange-50 text-orange-700 border-orange-200",
+  "left-wing": "bg-rose-50 text-rose-700 border-rose-200",
+  independent: "bg-slate-50 text-slate-700 border-slate-200",
+  centrist: "bg-indigo-50 text-indigo-700 border-indigo-200",
+};
+
+export default async function ItemDetailPage({
+  params,
+}: {
+  params: Promise<{ locale: string; id: string }>;
+}) {
+  const { locale, id } = await params;
+  const t = await getTranslations("news");
+  const isRTL = locale === "ar";
+
+  const item = await getItemById(id);
+  if (!item) notFound();
+
+  const itemRTL = item.language === "ar";
+  const catKey = CATEGORY_LABEL_KEY[item.category] ?? "general";
+  const catStyle =
+    CATEGORY_STYLE[item.category] ?? "bg-gray-50 text-gray-700 border-gray-200";
+  const oriStyle = item.politicalOrientation
+    ? (ORIENTATION_STYLE[item.politicalOrientation] ??
+      "bg-slate-50 text-slate-700 border-slate-200")
+    : null;
+
+  const published = new Date(item.publishedAt).toLocaleString(
+    locale === "ar" ? "ar-LB" : locale === "fr" ? "fr-FR" : "en-US",
+    { dateStyle: "medium", timeStyle: "short" },
+  );
+
+  return (
+    <div className="min-h-[calc(100dvh-64px)] bg-gray-50" dir={isRTL ? "rtl" : "ltr"}>
+      <div className="container mx-auto px-4 py-6 sm:py-10">
+        <div className="max-w-3xl mx-auto">
+          <Link
+            href={`/${locale}/news`}
+            className="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900 mb-4"
+          >
+            ← {isRTL ? "العودة إلى الأخبار" : locale === "fr" ? "Retour aux actualités" : "Back to news"}
+          </Link>
+
+          <article
+            className={`bg-white border ${item.isWarning ? "border-red-300 ring-1 ring-red-100" : "border-gray-200"} rounded-xl p-5 sm:p-8 shadow-sm`}
+          >
+            <div className="flex flex-wrap items-center gap-1.5 mb-4">
+              {item.isWarning && (
+                <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-red-200 bg-red-50 text-red-800 text-xs font-semibold uppercase tracking-wide">
+                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                    <path
+                      fillRule="evenodd"
+                      d="M8.485 3.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 3.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  {t("categories.alert")}
+                </span>
+              )}
+              <span
+                className={`inline-flex items-center px-2.5 py-1 rounded-md border text-xs font-medium ${catStyle}`}
+              >
+                {t(`categories.${catKey}`)}
+              </span>
+              {oriStyle && (
+                <span
+                  className={`inline-flex items-center px-2.5 py-1 rounded-md border text-xs ${oriStyle}`}
+                >
+                  {item.politicalOrientation}
+                </span>
+              )}
+              <span className="text-xs text-gray-400 uppercase tracking-wide ms-auto">
+                {item.language}
+              </span>
+            </div>
+
+            {item.imageUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={item.imageUrl}
+                alt=""
+                className="w-full max-h-96 object-cover rounded-lg bg-gray-100 mb-5"
+              />
+            )}
+
+            <div dir={itemRTL ? "rtl" : "ltr"}>
+              <h1 className="text-xl sm:text-2xl font-serif font-medium text-gray-900 leading-snug mb-3">
+                {item.title}
+              </h1>
+
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 mb-5">
+                <span className="font-medium text-gray-700">{item.sourceName}</span>
+                <span className="text-gray-300">·</span>
+                <time dateTime={item.publishedAt}>{published}</time>
+              </div>
+
+              <div className="prose prose-sm sm:prose-base max-w-none text-gray-800 whitespace-pre-wrap">
+                {item.body || item.summary}
+              </div>
+            </div>
+
+            <div className="mt-6 pt-4 border-t border-gray-100 flex items-center justify-between gap-3">
+              <a
+                href={item.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-cedar font-medium hover:underline"
+              >
+                {isRTL ? "فتح على Telegram" : locale === "fr" ? "Ouvrir sur Telegram" : "Open on Telegram"}
+                ↗
+              </a>
+              <span className="text-xs text-gray-400">#{item.id}</span>
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/news/page.tsx
+++ b/frontend/src/app/[locale]/news/page.tsx
@@ -1,83 +1,440 @@
-/**
- * TODO [Developer]: News Page
- *
- * This page previously displayed hardcoded mock news items (mockNewsItems).
- * It needs to be connected to a real data source. Steps to fix:
- *
- * 1. Create a News/Announcement model in the Prisma schema (see news-preview.tsx TODO).
- *
- * 2. Fetch real news data via the API client:
- *    - import { getNews } from "@/lib/api-client";
- *    - const newsItems = await getNews();
- *
- * 3. Render the news items. The previous UI had:
- *    - A hero section with icon, title, "Live" indicator, subtitle, description
- *    - A scrollable feed of news cards, each with:
- *      category badge (announcement/update/alert/general with color coding),
- *      relative timestamp ("5 mins ago"), headline, summary, "Read more" link
- *    - Links could be internal (/centers) or external (https://...)
- *    - Empty state when no news items exist
- *    - See git history for the full previous markup.
- *
- * 4. Category color mapping was:
- *    - announcement: blue-50/blue-700/blue-200
- *    - update: emerald-50/emerald-700/emerald-200
- *    - alert: amber-50/amber-700/amber-200
- *    - general: gray-50/gray-700/gray-200
- */
-
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
+import { getItems, getLatestItems, type NItem } from "@/lib/n-client";
+
+// Backend enrichment emits three categories: 'inzar' (إنذار / warnings),
+// 'politics', 'news'. 'inzar' items are exactly the warning-flagged ones.
+const CATEGORY_LABEL_KEY: Record<string, "alert" | "announcement" | "general"> = {
+  inzar: "alert",
+  politics: "announcement",
+  news: "general",
+};
+
+const CATEGORY_STYLE: Record<string, string> = {
+  inzar: "bg-amber-50 text-amber-800 border-amber-200",
+  politics: "bg-blue-50 text-blue-800 border-blue-200",
+  news: "bg-gray-50 text-gray-700 border-gray-200",
+};
+
+const ORIENTATION_STYLE: Record<string, string> = {
+  "pro-March 14": "bg-sky-50 text-sky-700 border-sky-200",
+  "pro-Hezbollah": "bg-yellow-50 text-yellow-800 border-yellow-200",
+  "pro-Amal": "bg-emerald-50 text-emerald-700 border-emerald-200",
+  "pro-FPM": "bg-orange-50 text-orange-700 border-orange-200",
+  "left-wing": "bg-rose-50 text-rose-700 border-rose-200",
+  independent: "bg-slate-50 text-slate-700 border-slate-200",
+  centrist: "bg-indigo-50 text-indigo-700 border-indigo-200",
+};
+
+function formatRelative(
+  iso: string,
+  labels: { justNow: string; minutesAgo: string; hoursAgo: string; daysAgo: string },
+): string {
+  const then = new Date(iso).getTime();
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (diffSec < 60) return labels.justNow;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} ${labels.minutesAgo}`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr} ${labels.hoursAgo}`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay} ${labels.daysAgo}`;
+}
+
+type SearchParams = {
+  category?: string;
+  language?: string;
+  q?: string;
+  page?: string;
+};
+
+function buildHref(
+  locale: string,
+  current: SearchParams,
+  patch: Partial<SearchParams>,
+): string {
+  const next = { ...current, ...patch };
+  // Clicking a filter chip resets to page 1
+  if (patch.category !== undefined || patch.language !== undefined || patch.q !== undefined) {
+    delete next.page;
+  }
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(next)) {
+    if (v && v !== "all") sp.set(k, String(v));
+  }
+  const query = sp.toString();
+  return `/${locale}/news${query ? `?${query}` : ""}`;
+}
+
+function Chip({
+  href,
+  active,
+  children,
+}: {
+  href: string;
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium transition-colors ${
+        active
+          ? "bg-cedar text-white border-cedar"
+          : "bg-white text-gray-700 border-gray-200 hover:bg-gray-50 hover:border-gray-300"
+      }`}
+    >
+      {children}
+    </Link>
+  );
+}
+
+const PAGE_SIZE = 30;
 
 export default async function NewsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<SearchParams>;
 }) {
   const { locale } = await params;
+  const sp = await searchParams;
   const t = await getTranslations("news");
   const isRTL = locale === "ar";
 
+  const category = sp.category && sp.category !== "all" ? sp.category : undefined;
+  const language = sp.language && sp.language !== "all" ? sp.language : undefined;
+  const q = sp.q?.trim() || undefined;
+  const page = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
+
+  let items: NItem[] = [];
+  let total = 0;
+  let totalPages = 1;
+  let fetchError: string | null = null;
+  const usingFilters = Boolean(category || language || q);
+  try {
+    const res = usingFilters
+      ? await getItems({ page, pageSize: PAGE_SIZE, category, language, q })
+      : await getLatestItems({ page, pageSize: PAGE_SIZE });
+    items = res.data;
+    total = res.total;
+    totalPages = res.totalPages;
+  } catch (err) {
+    fetchError = (err as Error).message;
+  }
+
+  const relativeLabels = {
+    justNow: t("justNow"),
+    minutesAgo: t("minutesAgo"),
+    hoursAgo: t("hoursAgo"),
+    daysAgo: t("daysAgo"),
+  };
+
+  const categoryChips: Array<{ value: string; label: string }> = [
+    { value: "all", label: isRTL ? "الكل" : locale === "fr" ? "Tout" : "All" },
+    { value: "inzar", label: t("categories.alert") },
+    { value: "politics", label: t("categories.announcement") },
+    { value: "news", label: t("categories.general") },
+  ];
+  const langChips: Array<{ value: string; label: string }> = [
+    { value: "all", label: isRTL ? "جميع اللغات" : locale === "fr" ? "Toutes" : "All languages" },
+    { value: "ar", label: "العربية" },
+    { value: "en", label: "English" },
+  ];
+  const activeCategory = category ?? "all";
+  const activeLanguage = language ?? "all";
+
   return (
     <div className="flex flex-col h-[calc(100dvh-64px)] overflow-hidden">
-      {/* Hero Section */}
-      <section className="flex-shrink-0 border-b border-gray-100 bg-white z-10" dir={isRTL ? "rtl" : "ltr"}>
+      {/* Hero */}
+      <section
+        className="flex-shrink-0 border-b border-gray-100 bg-white z-10"
+        dir={isRTL ? "rtl" : "ltr"}
+      >
         <div className="container mx-auto px-4 py-3 sm:py-5">
-          <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center gap-4 sm:gap-6">
+          <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center gap-4 sm:gap-6">
             <div className="flex-shrink-0">
               <div className="w-12 h-12 sm:w-14 sm:h-14 rounded-xl bg-gradient-to-br from-cedar/10 to-cedar/5 text-cedar flex items-center justify-center shadow-sm">
-                <svg className="w-6 h-6 sm:w-8 sm:h-8" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5M6 7.5h3v3H6v-3Z" />
+                <svg
+                  className="w-6 h-6 sm:w-8 sm:h-8"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5M6 7.5h3v3H6v-3Z"
+                  />
                 </svg>
               </div>
             </div>
-            <div className={`flex-1 text-center ${isRTL ? 'sm:text-right' : 'sm:text-left'}`}>
+            <div
+              className={`flex-1 text-center ${isRTL ? "sm:text-right" : "sm:text-left"}`}
+            >
               <h1 className="text-2xl sm:text-3xl font-serif font-medium text-gray-900 mb-1.5">
                 {t("title")}
               </h1>
               <p className="text-sm sm:text-base text-cedar font-medium">
                 {t("subtitle")}
               </p>
+              {total > 0 && (
+                <p className="text-xs text-gray-500 mt-1">
+                  {total.toLocaleString()}
+                  {usingFilters ? (isRTL ? " نتيجة" : locale === "fr" ? " résultats" : " results") : (isRTL ? " عنصر" : locale === "fr" ? " éléments" : " items")}
+                </p>
+              )}
+            </div>
+            <div className="flex-shrink-0 flex items-center gap-2">
+              <span className="relative flex h-2.5 w-2.5">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-red-500" />
+              </span>
+              <span className="text-xs text-gray-600 uppercase tracking-wide font-medium">
+                Live
+              </span>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Content — placeholder until real news data is connected */}
-      <section className="flex-1 overflow-y-auto min-h-0">
-        <div className="container mx-auto px-4 py-12 sm:py-16">
-          <div className="max-w-4xl mx-auto text-center py-16">
-            <div className="w-20 h-20 mx-auto mb-4 rounded-full bg-gray-100 flex items-center justify-center">
-              <svg className="w-10 h-10 text-gray-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5M6 7.5h3v3H6v-3Z" />
-              </svg>
-            </div>
-            <p className="text-gray-500 text-lg">
-              {locale === "ar"
-                ? "لا توجد أخبار متاحة حالياً"
-                : locale === "fr"
-                  ? "Aucune actualité disponible pour le moment"
-                  : "No news available at the moment"}
-            </p>
+      {/* Filters */}
+      <section
+        className="flex-shrink-0 border-b border-gray-100 bg-white"
+        dir={isRTL ? "rtl" : "ltr"}
+      >
+        <div className="container mx-auto px-4 py-3">
+          <div className="max-w-5xl mx-auto flex flex-wrap items-center gap-2">
+            {categoryChips.map((c) => (
+              <Chip
+                key={c.value}
+                href={buildHref(locale, sp, { category: c.value })}
+                active={activeCategory === c.value}
+              >
+                {c.value === "inzar" && (
+                  <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                    <path
+                      fillRule="evenodd"
+                      d="M8.485 3.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 3.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                )}
+                {c.label}
+              </Chip>
+            ))}
+            <span className="mx-2 h-5 w-px bg-gray-200" aria-hidden />
+            {langChips.map((l) => (
+              <Chip
+                key={l.value}
+                href={buildHref(locale, sp, { language: l.value })}
+                active={activeLanguage === l.value}
+              >
+                {l.label}
+              </Chip>
+            ))}
+            {usingFilters && (
+              <Link
+                href={`/${locale}/news`}
+                className="ms-auto text-xs text-gray-500 hover:text-gray-700 underline"
+              >
+                {isRTL ? "مسح الفلاتر" : locale === "fr" ? "Effacer" : "Clear"}
+              </Link>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* Feed */}
+      <section className="flex-1 overflow-y-auto min-h-0 bg-gray-50">
+        <div className="container mx-auto px-4 py-6 sm:py-8">
+          <div className="max-w-5xl mx-auto">
+            {fetchError ? (
+              <div className="bg-red-50 border border-red-200 text-red-800 rounded-lg p-4 text-sm">
+                <p className="font-semibold mb-1">Failed to load news feed</p>
+                <p className="opacity-80">{fetchError}</p>
+                <p className="opacity-60 mt-2 text-xs">
+                  Check that the Daleel backend is running and reachable at{" "}
+                  {process.env.NEXT_PUBLIC_DALEEL_API_URL ??
+                    "http://localhost:3000"}
+                  .
+                </p>
+              </div>
+            ) : items.length === 0 ? (
+              <div className="text-center py-16">
+                <div className="w-20 h-20 mx-auto mb-4 rounded-full bg-gray-100 flex items-center justify-center">
+                  <svg
+                    className="w-10 h-10 text-gray-400"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5M6 7.5h3v3H6v-3Z"
+                    />
+                  </svg>
+                </div>
+                <p className="text-gray-500 text-lg">
+                  {isRTL
+                    ? "لا توجد أخبار متاحة حالياً"
+                    : locale === "fr"
+                      ? "Aucune actualité disponible pour le moment"
+                      : "No news available at the moment"}
+                </p>
+              </div>
+            ) : (
+              <>
+                <ul className="grid gap-3 sm:gap-4">
+                  {items.map((item) => {
+                    const itemRTL = item.language === "ar";
+                    const catKey = CATEGORY_LABEL_KEY[item.category] ?? "general";
+                    const catStyle =
+                      CATEGORY_STYLE[item.category] ??
+                      "bg-gray-50 text-gray-700 border-gray-200";
+                    const oriStyle = item.politicalOrientation
+                      ? (ORIENTATION_STYLE[item.politicalOrientation] ??
+                        "bg-slate-50 text-slate-700 border-slate-200")
+                      : null;
+                    return (
+                      <li key={item.id}>
+                        <article
+                          className={`bg-white border ${item.isWarning ? "border-red-300 shadow-sm ring-1 ring-red-100" : "border-gray-200"} rounded-lg p-4 sm:p-5 hover:border-gray-300 transition-colors`}
+                        >
+                          <div className="flex items-start gap-3 sm:gap-4">
+                            {item.imageUrl ? (
+                              // eslint-disable-next-line @next/next/no-img-element
+                              <img
+                                src={item.imageUrl}
+                                alt=""
+                                loading="lazy"
+                                className="flex-shrink-0 w-20 h-20 sm:w-24 sm:h-24 rounded-md object-cover bg-gray-100"
+                              />
+                            ) : null}
+                            <div
+                              className="flex-1 min-w-0"
+                              dir={itemRTL ? "rtl" : "ltr"}
+                            >
+                              <div className="flex flex-wrap items-center gap-1.5 mb-2">
+                                {item.isWarning && (
+                                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-red-200 bg-red-50 text-red-800 text-xs font-semibold uppercase tracking-wide">
+                                    <svg
+                                      className="w-3 h-3"
+                                      fill="currentColor"
+                                      viewBox="0 0 20 20"
+                                    >
+                                      <path
+                                        fillRule="evenodd"
+                                        d="M8.485 3.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 3.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                                        clipRule="evenodd"
+                                      />
+                                    </svg>
+                                    {t("categories.alert")}
+                                  </span>
+                                )}
+                                <span
+                                  className={`inline-flex items-center px-2 py-0.5 rounded-md border text-xs font-medium ${catStyle}`}
+                                >
+                                  {t(`categories.${catKey}`)}
+                                </span>
+                                {oriStyle && (
+                                  <span
+                                    className={`inline-flex items-center px-2 py-0.5 rounded-md border text-xs ${oriStyle}`}
+                                  >
+                                    {item.politicalOrientation}
+                                  </span>
+                                )}
+                                <span className="text-xs text-gray-400 uppercase tracking-wide">
+                                  {item.language}
+                                </span>
+                                <span className="text-xs text-gray-400">·</span>
+                                <span className="text-xs text-gray-500">
+                                  {formatRelative(item.publishedAt, relativeLabels)}
+                                </span>
+                              </div>
+                              <Link
+                                href={`/${locale}/news/${item.id}`}
+                                className="block group"
+                              >
+                                <h3 className="text-sm sm:text-base font-semibold text-gray-900 leading-snug line-clamp-2 group-hover:text-cedar transition-colors">
+                                  {item.title}
+                                </h3>
+                                {item.summary && item.summary !== item.title && (
+                                  <p className="text-xs sm:text-sm text-gray-600 mt-1.5 line-clamp-3">
+                                    {item.summary}
+                                  </p>
+                                )}
+                              </Link>
+                              <div className="flex items-center justify-between mt-2.5 gap-2">
+                                <span className="text-xs text-gray-500 truncate">
+                                  {item.sourceName}
+                                </span>
+                                <div className="flex-shrink-0 flex items-center gap-3">
+                                  <a
+                                    href={item.sourceUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs text-gray-500 hover:text-gray-700"
+                                  >
+                                    {isRTL ? "المصدر" : locale === "fr" ? "Source" : "Source"} ↗
+                                  </a>
+                                  <Link
+                                    href={`/${locale}/news/${item.id}`}
+                                    className="text-xs text-cedar font-medium hover:underline"
+                                  >
+                                    {t("readMore")} →
+                                  </Link>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </article>
+                      </li>
+                    );
+                  })}
+                </ul>
+
+                {/* Pagination */}
+                {totalPages > 1 && (
+                  <nav
+                    className="mt-6 flex items-center justify-between"
+                    aria-label="Pagination"
+                  >
+                    {page > 1 ? (
+                      <Link
+                        href={buildHref(locale, sp, { page: String(page - 1) })}
+                        className="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-gray-200 bg-white text-sm text-gray-700 hover:bg-gray-50"
+                      >
+                        ← {isRTL ? "السابق" : locale === "fr" ? "Précédent" : "Previous"}
+                      </Link>
+                    ) : (
+                      <span />
+                    )}
+                    <span className="text-sm text-gray-500">
+                      {isRTL
+                        ? `${page} من ${totalPages}`
+                        : locale === "fr"
+                          ? `${page} sur ${totalPages}`
+                          : `Page ${page} of ${totalPages}`}
+                    </span>
+                    {page < totalPages ? (
+                      <Link
+                        href={buildHref(locale, sp, { page: String(page + 1) })}
+                        className="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-gray-200 bg-white text-sm text-gray-700 hover:bg-gray-50"
+                      >
+                        {isRTL ? "التالي" : locale === "fr" ? "Suivant" : "Next"} →
+                      </Link>
+                    ) : (
+                      <span />
+                    )}
+                  </nav>
+                )}
+              </>
+            )}
           </div>
         </div>
       </section>

--- a/frontend/src/components/news-preview.tsx
+++ b/frontend/src/components/news-preview.tsx
@@ -1,53 +1,143 @@
-/**
- * TODO [Developer]: News Preview Section
- *
- * This component previously used hardcoded mock news data (mockNewsItems).
- * It needs to be connected to a real data source. Steps to fix:
- *
- * 1. Create a News/Announcement model in the Prisma schema with fields:
- *    - id, category (announcement|update|alert|general), publishedAt,
- *    - headlineAr, headlineEn, headlineFr, summaryAr, summaryEn, summaryFr,
- *    - link (internal path or external URL)
- *
- * 2. Create a backend API endpoint: GET /api/public/news
- *    - Return latest news items, ordered by publishedAt desc
- *    - Follow the pattern in backend/src/api/public/candidates.ts
- *
- * 3. Add getNews() to frontend/src/lib/api-client.ts
- *    - Follow the pattern of getCandidates()
- *
- * 4. Fetch real news data in this component and render it.
- *    - The previous UI rendered a grid of news cards with:
- *      category badge, timestamp (relative "X mins ago"), headline, summary,
- *      and a link (internal or external). See git history for the old markup.
- *
- * 5. The home page (app/[locale]/page.tsx) renders <NewsPreview locale={locale} />.
- *    Make sure the component still accepts { locale: string } as a prop.
- */
-
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { Newspaper } from "lucide-react";
 import { SectionHeader } from "@/components/ui/section-header";
+import { getLatestItems, type NItem } from "@/lib/n-client";
+
+const CATEGORY_STYLE: Record<string, string> = {
+  inzar: "bg-amber-50 text-amber-800 border-amber-200",
+  politics: "bg-blue-50 text-blue-800 border-blue-200",
+  news: "bg-gray-50 text-gray-700 border-gray-200",
+};
+
+const CATEGORY_LABEL_KEY: Record<string, "alert" | "announcement" | "general"> = {
+  inzar: "alert",
+  politics: "announcement",
+  news: "general",
+};
+
+function formatRelative(
+  iso: string,
+  labels: { justNow: string; minutesAgo: string; hoursAgo: string; daysAgo: string },
+): string {
+  const then = new Date(iso).getTime();
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (diffSec < 60) return labels.justNow;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} ${labels.minutesAgo}`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr} ${labels.hoursAgo}`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay} ${labels.daysAgo}`;
+}
 
 export default async function NewsPreview({ locale }: { locale: string }) {
   const t = await getTranslations("news");
+  const isRTL = locale === "ar";
+
+  let items: NItem[] = [];
+  try {
+    const res = await getLatestItems({ pageSize: 6 });
+    items = res.data;
+  } catch {
+    // Fall through to the "coming soon" state — home page should never fail to
+    // render just because the ingestion backend is unreachable.
+    items = [];
+  }
+
+  const labels = {
+    justNow: t("justNow"),
+    minutesAgo: t("minutesAgo"),
+    hoursAgo: t("hoursAgo"),
+    daysAgo: t("daysAgo"),
+  };
 
   return (
     <section className="container mx-auto px-4 pb-16 sm:pb-20 md:pb-24">
       <div className="max-w-5xl mx-auto">
         <SectionHeader icon={Newspaper} title={t("title")} />
 
-        {/* Placeholder until real news data is connected */}
-        <div className="text-center py-12 bg-gray-50 rounded-2xl border border-dashed border-gray-200">
-          <Newspaper className="w-10 h-10 text-gray-300 mx-auto mb-3" />
-          <p className="text-sm text-gray-400">
-            {locale === "ar"
-              ? "قريباً — الأخبار والتحديثات"
-              : locale === "fr"
-                ? "Bientôt — Actualités et mises à jour"
-                : "Coming soon — News & updates"}
-          </p>
-        </div>
+        {items.length === 0 ? (
+          <div className="text-center py-12 bg-gray-50 rounded-2xl border border-dashed border-gray-200">
+            <Newspaper className="w-10 h-10 text-gray-300 mx-auto mb-3" />
+            <p className="text-sm text-gray-400">
+              {isRTL
+                ? "قريباً — الأخبار والتحديثات"
+                : locale === "fr"
+                  ? "Bientôt — Actualités et mises à jour"
+                  : "Coming soon — News & updates"}
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-3 sm:gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+              {items.map((item) => {
+                const itemRTL = item.language === "ar";
+                const catKey = CATEGORY_LABEL_KEY[item.category] ?? "general";
+                const catStyle =
+                  CATEGORY_STYLE[item.category] ??
+                  "bg-gray-50 text-gray-700 border-gray-200";
+                return (
+                  <Link
+                    key={item.id}
+                    href={`/${locale}/news/${item.id}`}
+                    className={`group block bg-white border ${item.isWarning ? "border-red-200 hover:border-red-300 ring-1 ring-red-50" : "border-gray-200 hover:border-cedar/30"} rounded-xl p-4 transition-colors`}
+                  >
+                    <div className="flex items-center gap-1.5 mb-2 text-xs">
+                      {item.isWarning && (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-red-200 bg-red-50 text-red-800 font-semibold uppercase tracking-wide">
+                          {t("categories.alert")}
+                        </span>
+                      )}
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-md border font-medium ${catStyle}`}
+                      >
+                        {t(`categories.${catKey}`)}
+                      </span>
+                      <span className="ms-auto text-gray-400">
+                        {formatRelative(item.publishedAt, labels)}
+                      </span>
+                    </div>
+                    <h3
+                      dir={itemRTL ? "rtl" : "ltr"}
+                      className="text-sm font-semibold text-gray-900 leading-snug line-clamp-3 group-hover:text-cedar transition-colors"
+                    >
+                      {item.title}
+                    </h3>
+                    <p className="mt-2 text-xs text-gray-500 truncate">
+                      {item.sourceName}
+                    </p>
+                  </Link>
+                );
+              })}
+            </div>
+            <div className="mt-5 text-center">
+              <Link
+                href={`/${locale}/news`}
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-cedar hover:underline"
+              >
+                {isRTL
+                  ? "عرض كل الأخبار"
+                  : locale === "fr"
+                    ? "Voir toutes les actualités"
+                    : "See all news"}
+                <svg
+                  className={`w-4 h-4 ${isRTL ? "rotate-180" : ""}`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+                  />
+                </svg>
+              </Link>
+            </div>
+          </>
+        )}
       </div>
     </section>
   );

--- a/frontend/src/lib/n-client.ts
+++ b/frontend/src/lib/n-client.ts
@@ -1,0 +1,96 @@
+/**
+ * Client for the Daleel-Backend public "N" API (normalized items ingested from
+ * Telegram channels). Separate from api-client.ts which talks to the in-repo
+ * election backend — this one hits an external service whose URL is configured
+ * via NEXT_PUBLIC_DALEEL_API_URL.
+ */
+
+export type NItem = {
+  id: number;
+  title: string;
+  summary: string;
+  body: string;
+  imageUrl: string | null;
+  sourceUrl: string;
+  sourceName: string;
+  politicalOrientation: string | null;
+  category: string;
+  tags: string[];
+  sentiment: string | null;
+  entities: unknown[];
+  isWarning: boolean;
+  status: string;
+  language: string;
+  publishedAt: string;
+  createdAt: string;
+  updatedAt: string;
+  fetchedAt: string;
+};
+
+type ListResponse = {
+  success: true;
+  data: NItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_DALEEL_API_URL?.replace(/\/$/, "") ??
+  "http://localhost:3000";
+
+async function nFetch<T>(path: string, revalidate = 60): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    next: { revalidate },
+  });
+  if (!res.ok) {
+    throw new Error(`Daleel N API ${res.status} ${res.statusText} — ${path}`);
+  }
+  return res.json();
+}
+
+export async function getLatestItems(
+  params: { page?: number; pageSize?: number } = {},
+): Promise<ListResponse> {
+  const sp = new URLSearchParams();
+  if (params.page) sp.set("page", String(params.page));
+  if (params.pageSize) sp.set("pageSize", String(params.pageSize));
+  const query = sp.toString();
+  return nFetch<ListResponse>(`/api/n/latest${query ? `?${query}` : ""}`);
+}
+
+export async function getItemById(id: number | string): Promise<NItem | null> {
+  try {
+    const res = await nFetch<{ success: true; data: NItem }>(
+      `/api/n/${encodeURIComponent(String(id))}`,
+      60,
+    );
+    return res.data;
+  } catch (err) {
+    // 404s are a normal "not found", not an error to surface
+    if ((err as Error).message.includes(" 404 ")) return null;
+    throw err;
+  }
+}
+
+export async function getItems(
+  params: {
+    page?: number;
+    pageSize?: number;
+    category?: string;
+    tag?: string;
+    language?: string;
+    q?: string;
+  } = {},
+): Promise<ListResponse> {
+  const sp = new URLSearchParams();
+  if (params.page) sp.set("page", String(params.page));
+  if (params.pageSize) sp.set("pageSize", String(params.pageSize));
+  if (params.category) sp.set("category", params.category);
+  if (params.tag) sp.set("tag", params.tag);
+  if (params.language) sp.set("language", params.language);
+  if (params.q) sp.set("q", params.q);
+  const query = sp.toString();
+  return nFetch<ListResponse>(`/api/n/list${query ? `?${query}` : ""}`);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2020"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Connects the `/[locale]/news` page and homepage news preview to the Daleel-Backend public API (`/api/n/*`), replacing the placeholders. The backend is a separate service (laythayache/Daleel-Backend) that ingests Telegram channels into a normalized `N` item shape; this PR makes the public site a thin display layer on top of it.

- **`frontend/src/lib/n-client.ts`** — typed `NItem` + `getLatestItems` / `getItems` / `getItemById` helpers hitting `/api/n/*`. Base URL from `NEXT_PUBLIC_DALEEL_API_URL` (defaults to `http://localhost:3000` for local dev).
- **`frontend/src/app/[locale]/news/page.tsx`** — live feed with URL-driven filters (category: all / alert / announcement / general; language: all / ar / en), pagination, per-item warning badges, political-orientation chips, per-item RTL.
- **`frontend/src/app/[locale]/news/[id]/page.tsx`** — new detail page rendering full body, localized publish timestamp, source link to original Telegram post.
- **`frontend/src/components/news-preview.tsx`** — home page preview replaces the "coming soon" placeholder with 6 latest items + "See all news" link.

## Test plan

- [ ] `NEXT_PUBLIC_DALEEL_API_URL` set in `.env.local` (not committed)
- [ ] Daleel-Backend running and reachable
- [ ] Visit `/en/news` — sees 30-item feed, category + language chips work, pagination works
- [ ] Visit `/en/news?category=inzar` — only warning-flagged items
- [ ] Click any item → detail page renders full body
- [ ] Visit `/en` — news preview section shows 6 latest
- [ ] Visit `/ar/news` — Arabic-language items with RTL rendering
- [ ] Stop backend → news page falls back to "Failed to load" banner; home preview silently hides to "Coming soon"

🤖 Generated with [Claude Code](https://claude.com/claude-code)